### PR TITLE
Add basic UI tests for example test scenarios

### DIFF
--- a/StapelUITests/App/App.swift
+++ b/StapelUITests/App/App.swift
@@ -1,18 +1,77 @@
 import SwiftUI
 import Stapel
+
+
+struct StapelSimpleScenario: View {
+    var body: some View {
+        VStack {
+            Text("Hello world!")
+            StackNavigationLink(label: {
+                Text("Push")
+            }, content: {
+                Text("Pushed view")
+            })
+        }
+    }
+}
+
+struct StapelNestedScenario: View {
+    var body: some View {
+        VStack {
+            Text("Root View").navigationBarTitle("Root view")
+            StackNavigationLink(label: {
+                Text("Push another view")
+            }) {
+                WithPusher {
+                    Text("Second view").navigationBarTitle("Second view")
+                    StackNavigationLink(label: {
+                        Text("Push yet another view")
+                    }) {
+                        WithPusher {
+                            Text("Third view").navigationBarTitle("Third view")
+                            StackNavigationLink(label: {
+                                Text("And another view")
+                            }) {
+                                WithPusher {
+                                    Text("Fourth view").navigationBarTitle("Fourth view")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct StapelWithoutVStackScenario: View {
+    var body: some View {
+        Text("Should be visible")
+        Text("This too")
+    }
+}
+
 @main
 struct StapelUITestsApp: App {
     @StateObject var stack = Stack()
     
+    func renderBody () -> AnyView {
+        switch ProcessInfo.processInfo.environment["test_scenario"] {
+        case "nested":
+            return AnyView(StapelNestedScenario())
+        case "without_vstack":
+            return AnyView(StapelWithoutVStackScenario())
+        case "simple":
+            fallthrough
+        default:
+            return AnyView(StapelSimpleScenario())
+        }
+    }
+    
     var body: some Scene {
         WindowGroup {
             WithStapel {
-                Text("Hello world!")
-                StackNavigationLink(label: {
-                    Text("Push")
-                }, content: {
-                    Text("Pushed view")
-                })
+                renderBody()
             }
             .environmentObject(stack)
         }

--- a/StapelUITests/App/App.swift
+++ b/StapelUITests/App/App.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import Stapel
+@main
+struct StapelUITestsApp: App {
+    @StateObject var stack = Stack()
+    
+    var body: some Scene {
+        WindowGroup {
+            WithStapel {
+                Text("Hello world!")
+                StackNavigationLink(label: {
+                    Text("Push")
+                }, content: {
+                    Text("Pushed view")
+                })
+            }
+            .environmentObject(stack)
+        }
+    }
+}

--- a/StapelUITests/App/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/StapelUITests/App/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/StapelUITests/App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/StapelUITests/App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/StapelUITests/App/Assets.xcassets/Contents.json
+++ b/StapelUITests/App/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/StapelUITests/App/Info.plist
+++ b/StapelUITests/App/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/StapelUITests/App/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/StapelUITests/App/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/StapelUITests/StapelUITests.xcodeproj/project.pbxproj
+++ b/StapelUITests/StapelUITests.xcodeproj/project.pbxproj
@@ -1,0 +1,487 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		157D28B0259FA61800DA1642 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157D28AF259FA61800DA1642 /* App.swift */; };
+		157D28B4259FA61900DA1642 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 157D28B3259FA61900DA1642 /* Assets.xcassets */; };
+		157D28B7259FA61900DA1642 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 157D28B6259FA61900DA1642 /* Preview Assets.xcassets */; };
+		157D28CD259FA61A00DA1642 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157D28CC259FA61A00DA1642 /* Tests.swift */; };
+		157D290F259FAAD600DA1642 /* Stapel in Frameworks */ = {isa = PBXBuildFile; productRef = 157D290E259FAAD600DA1642 /* Stapel */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		157D28C9259FA61A00DA1642 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 157D28A4259FA61700DA1642 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 157D28AB259FA61800DA1642;
+			remoteInfo = StapelUITests;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		157D28AF259FA61800DA1642 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
+		157D28B3259FA61900DA1642 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		157D28B6259FA61900DA1642 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		157D28B8259FA61900DA1642 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		157D28CC259FA61A00DA1642 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
+		157D28CE259FA61A00DA1642 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		157D28E0259FA6A000DA1642 /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		157D28E2259FA6A000DA1642 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		157D290A259FAA2900DA1642 /* Stapel */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Stapel; path = ..; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		157D28A9259FA61800DA1642 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				157D290F259FAAD600DA1642 /* Stapel in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		157D28C5259FA61A00DA1642 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		157D28A3259FA61700DA1642 = {
+			isa = PBXGroup;
+			children = (
+				157D28AE259FA61800DA1642 /* App */,
+				157D28CB259FA61A00DA1642 /* Tests */,
+				157D28E0259FA6A000DA1642 /* App.app */,
+				157D28E2259FA6A000DA1642 /* Tests.xctest */,
+				157D2909259FAA2900DA1642 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		157D28AE259FA61800DA1642 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				157D28AF259FA61800DA1642 /* App.swift */,
+				157D28B3259FA61900DA1642 /* Assets.xcassets */,
+				157D28B8259FA61900DA1642 /* Info.plist */,
+				157D28B5259FA61900DA1642 /* Preview Content */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		157D28B5259FA61900DA1642 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				157D28B6259FA61900DA1642 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		157D28CB259FA61A00DA1642 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				157D28CC259FA61A00DA1642 /* Tests.swift */,
+				157D28CE259FA61A00DA1642 /* Info.plist */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		157D2909259FAA2900DA1642 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				157D290A259FAA2900DA1642 /* Stapel */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		157D28AB259FA61800DA1642 /* App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 157D28D1259FA61A00DA1642 /* Build configuration list for PBXNativeTarget "App" */;
+			buildPhases = (
+				157D28A8259FA61800DA1642 /* Sources */,
+				157D28A9259FA61800DA1642 /* Frameworks */,
+				157D28AA259FA61800DA1642 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = App;
+			packageProductDependencies = (
+				157D290E259FAAD600DA1642 /* Stapel */,
+			);
+			productName = StapelUITests;
+			productReference = 157D28E0259FA6A000DA1642 /* App.app */;
+			productType = "com.apple.product-type.application";
+		};
+		157D28C7259FA61A00DA1642 /* Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 157D28D7259FA61A00DA1642 /* Build configuration list for PBXNativeTarget "Tests" */;
+			buildPhases = (
+				157D28C4259FA61A00DA1642 /* Sources */,
+				157D28C5259FA61A00DA1642 /* Frameworks */,
+				157D28C6259FA61A00DA1642 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				157D28CA259FA61A00DA1642 /* PBXTargetDependency */,
+			);
+			name = Tests;
+			productName = StapelUITestsUITests;
+			productReference = 157D28E2259FA6A000DA1642 /* Tests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		157D28A4259FA61700DA1642 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1230;
+				LastUpgradeCheck = 1230;
+				TargetAttributes = {
+					157D28AB259FA61800DA1642 = {
+						CreatedOnToolsVersion = 12.3;
+					};
+					157D28C7259FA61A00DA1642 = {
+						CreatedOnToolsVersion = 12.3;
+						TestTargetID = 157D28AB259FA61800DA1642;
+					};
+				};
+			};
+			buildConfigurationList = 157D28A7259FA61700DA1642 /* Build configuration list for PBXProject "StapelUITests" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 157D28A3259FA61700DA1642;
+			packageReferences = (
+				157D290D259FAAD600DA1642 /* XCRemoteSwiftPackageReference "Stapel" */,
+			);
+			productRefGroup = 157D28A3259FA61700DA1642;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				157D28AB259FA61800DA1642 /* App */,
+				157D28C7259FA61A00DA1642 /* Tests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		157D28AA259FA61800DA1642 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				157D28B7259FA61900DA1642 /* Preview Assets.xcassets in Resources */,
+				157D28B4259FA61900DA1642 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		157D28C6259FA61A00DA1642 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		157D28A8259FA61800DA1642 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				157D28B0259FA61800DA1642 /* App.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		157D28C4259FA61A00DA1642 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				157D28CD259FA61A00DA1642 /* Tests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		157D28CA259FA61A00DA1642 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 157D28AB259FA61800DA1642 /* App */;
+			targetProxy = 157D28C9259FA61A00DA1642 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		157D28CF259FA61A00DA1642 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		157D28D0259FA61A00DA1642 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		157D28D2259FA61A00DA1642 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"App/Preview Content\"";
+				DEVELOPMENT_TEAM = HS8WFNRJR6;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = App/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.brunoscheufler.Stapel.UITests.App;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		157D28D3259FA61A00DA1642 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"App/Preview Content\"";
+				DEVELOPMENT_TEAM = HS8WFNRJR6;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = App/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.brunoscheufler.Stapel.UITests.App;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		157D28D8259FA61A00DA1642 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = HS8WFNRJR6;
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.brunoscheufler.Stapel.UITests.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App;
+			};
+			name = Debug;
+		};
+		157D28D9259FA61A00DA1642 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = HS8WFNRJR6;
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.brunoscheufler.Stapel.UITests.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		157D28A7259FA61700DA1642 /* Build configuration list for PBXProject "StapelUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				157D28CF259FA61A00DA1642 /* Debug */,
+				157D28D0259FA61A00DA1642 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		157D28D1259FA61A00DA1642 /* Build configuration list for PBXNativeTarget "App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				157D28D2259FA61A00DA1642 /* Debug */,
+				157D28D3259FA61A00DA1642 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		157D28D7259FA61A00DA1642 /* Build configuration list for PBXNativeTarget "Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				157D28D8259FA61A00DA1642 /* Debug */,
+				157D28D9259FA61A00DA1642 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		157D290D259FAAD600DA1642 /* XCRemoteSwiftPackageReference "Stapel" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/BrunoScheufler/Stapel.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		157D290E259FAAD600DA1642 /* Stapel */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 157D290D259FAAD600DA1642 /* XCRemoteSwiftPackageReference "Stapel" */;
+			productName = Stapel;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 157D28A4259FA61700DA1642 /* Project object */;
+}

--- a/StapelUITests/StapelUITests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/StapelUITests/StapelUITests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/StapelUITests/StapelUITests.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/StapelUITests/StapelUITests.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/StapelUITests/StapelUITests.xcodeproj/xcshareddata/xcschemes/StapelUITests.xcscheme
+++ b/StapelUITests/StapelUITests.xcodeproj/xcshareddata/xcschemes/StapelUITests.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1230"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "157D28AB259FA61800DA1642"
+               BuildableName = "App.app"
+               BlueprintName = "App"
+               ReferencedContainer = "container:StapelUITests.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "157D28C7259FA61A00DA1642"
+               BuildableName = "Tests.xctest"
+               BlueprintName = "Tests"
+               ReferencedContainer = "container:StapelUITests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "157D28AB259FA61800DA1642"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:StapelUITests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "157D28AB259FA61800DA1642"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:StapelUITests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/StapelUITests/Tests/Info.plist
+++ b/StapelUITests/Tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/StapelUITests/Tests/Tests.swift
+++ b/StapelUITests/Tests/Tests.swift
@@ -1,35 +1,129 @@
 import XCTest
 
 class Tests: XCTestCase {
-
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
-
+        
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-
+        
         // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
-
+    
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-
-    func testExample() throws {
+    
+    func testLaunch() throws {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
         app.launch()
-
+        
+        
         // Use recording to get started writing UI tests.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
-
-    func testLaunchPerformance() throws {
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, *) {
-            // This measures how long it takes to launch your application.
-            measure(metrics: [XCTApplicationLaunchMetric()]) {
-                XCUIApplication().launch()
-            }
-        }
+    
+    func launchApp(_ scenario: String = "simple") -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchEnvironment["test_scenario"] = scenario
+        app.launch()
+        
+        return app
+    }
+    
+    func testWithoutVStack() {
+        let app = launchApp("without_vstack")
+        
+        XCTAssert(app.staticTexts["Should be visible"].exists)
+        XCTAssert(app.staticTexts["This too"].exists)
+    }
+    
+    func testPush() throws {
+        let app = launchApp()
+        
+        XCTAssert(app.buttons["Push"].exists)
+        app.buttons["Push"].tap()
+        XCTAssert(app.staticTexts["Pushed view"].exists)
+    }
+    
+    func testPop() throws {
+        let app = launchApp()
+        
+        
+        XCTAssert(app.staticTexts["Hello world!"].exists)
+        
+        let pushButton = app.buttons["Push"]
+        pushButton.tap()
+        
+        XCTAssert(app.staticTexts["Pushed view"].exists)
+        
+        let backButton = app.navigationBars["_TtGC7SwiftUIP13$7fff5767130428DestinationHosting"].buttons["Back"]
+        backButton.tap()
+        
+        XCTAssert(app.staticTexts["Hello world!"].exists)
+        XCTAssert(!app.staticTexts["Pushed view"].exists)
+        
+        pushButton.tap()
+        XCTAssert(app.staticTexts["Pushed view"].exists)
+        XCTAssert(!app.staticTexts["Hello world!"].exists)
+        
+        backButton.tap()
+        
+        XCTAssert(app.staticTexts["Hello world!"].exists)
+        XCTAssert(!app.staticTexts["Pushed view"].exists)
+    }
+    
+    func testNestedNavigation() {
+        let app = launchApp("nested")
+        
+        XCTAssert(app.staticTexts["Root View"].exists)
+        
+        let toSecond = app.buttons["Push another view"]
+        toSecond.tap()
+        
+        XCTAssert(!app.staticTexts["Root View"].exists)
+        XCTAssert(app.staticTexts["Second view"].exists)
+        
+        let toThird = app.buttons["Push yet another view"]
+        toThird.tap()
+        
+        XCTAssert(!app.staticTexts["Second view"].exists)
+        XCTAssert(app.staticTexts["Third view"].exists)
+        
+        
+        let toFourth = app.buttons["And another view"]
+        toFourth.tap()
+        
+        XCTAssert(app.staticTexts["Fourth view"].exists)
+        
+        let backToThird = app.navigationBars["Fourth view"].buttons["Third view"]
+        backToThird.tap()
+        
+        XCTAssert(!app.staticTexts["Fourth view"].exists)
+        XCTAssert(app.staticTexts["Third view"].exists)
+        
+        let backToSecond = app.navigationBars["Third view"].buttons["Second view"]
+        backToSecond.tap()
+                
+        XCTAssert(!app.staticTexts["Third view"].exists)
+        XCTAssert(app.staticTexts["Second view"].exists)
+        
+        let backToFirst = app.navigationBars["Second view"].buttons["Root view"]
+        backToFirst.tap()
+        
+        XCTAssert(!app.staticTexts["Second view"].exists)
+        XCTAssert(app.staticTexts["Root view"].exists)
+        
+        toSecond.tap()
+        toThird.tap()
+        toFourth.tap()
+        backToThird.tap()
+        toFourth.tap()
+        backToThird.tap()
+        backToSecond.tap()
+        backToFirst.tap()
+        toSecond.tap()
+        backToFirst.tap()
     }
 }

--- a/StapelUITests/Tests/Tests.swift
+++ b/StapelUITests/Tests/Tests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+class Tests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This makes sure the code offered in the examples works as expected and we don't introduce regressions down the road.
Unfortunately, it doesn't seem like there's a way to test context menus, so we can't add a test for the navigation back button just yet.