### PR TITLE
Push evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,102 @@ struct ContentView: View {
 
 
 As you can see, you can go on and on (please split out your sub-views though).
+
+### Push evaluation
+
+In specific cases, you might like to prevent pushes to the active pusher. If the view that you'd push is equal to the current view, for example, it wouldn't make
+much sense to push it to the stack again. Especially for programmatic navigation, it can be helpful to add a condition when a push should happen, and to be able
+to check if a push would succeed. This is why Stapel offers Push evaluation for each registered pusher.
+
+Setting up push evaluation requires two steps: Adding an evaluation function to the pusher that you'd like to control, and supplying context when pushing.
+
+#### Adding an evaluation function
+
+During each push, we check whether an evaluation function was set for the pusher that would receive the view to be pushed.
+If no function exists, the push will _always_ be allowed.
+If an evaluation function is set, we will invoke it and pass the supplied context.
+If the evaluation function returns `true`, we'll push the view onto the stack, otherwise it'll be a no-op.
+
+Let's see how we'd register an evaluation function on our root level. If this evaluates to false, we won't onto that.
+
+```swift
+struct ContentView: View {
+    @StateObject var stack = Stack()
+    
+    var body: some View {
+        WithStapel({ (context) -> Bool in
+            guard let hasExpected = context["expected"] else {
+                return false
+            }
+            guard let isString = hasExpected as? String else {
+                return false
+            }
+            return isString == "value"
+        }) {
+            Text("Root view")
+            Button(action: {
+                stack.push(view: AnyView(Text("No-op")))
+            }, label: {
+                Text("Push falsy")
+            })
+            Button(action: {
+                stack.push(view: AnyView(Text("Pushed with evaluation")), context: ["expected" : "value"])
+            }, label: {
+                Text("Push truthy")
+            })
+        }
+        .environmentObject(stack)
+    }
+}
+```
+
+This will render two buttons on the root level, one that will supply the expected context and result in a push, and
+another one that will not push, as it doesn't supply a context (or an invaild context).
+
+While this only affects the initial layer, we might also want to control subsequent layers. This can be done by supplying an evaluation
+function to `WithPusher`.
+
+```swift
+struct ContentView: View {
+    @StateObject var stack = Stack()
+    var body: some View {
+        // Initial layer, will always push
+        WithStapel {
+            VStack {
+                Text("Root View").navigationBarTitle("Root view")
+                StackNavigationLink(label: {
+                    Text("Push another view")
+                }) {
+                    
+                    // Second layer, only push further view if evaluation succeeds
+                    WithPusher({ (context) -> Bool in
+                        guard let hasExpected = context["expected"] else {
+                            return false
+                        }
+                        guard let isString = hasExpected as? String else {
+                            return false
+                        }
+                        return isString == "value"
+                    }) {
+                        Text("Second view").navigationBarTitle("Second view")
+                        Button(action: {
+                            stack.push(view: AnyView(Text("No-op")))
+                        }, label: {
+                            Text("Push falsy")
+                        })
+                        Button(action: {
+                            stack.push(view: AnyView(Text("Pushed with evaluation")), context: ["expected" : "value"])
+                        }, label: {
+                            Text("Push truthy")
+                        })
+                    }
+                    
+                }
+            }
+        }
+        .environmentObject(stack)
+    }
+}
+```
+
+#### Supplying context on push

--- a/README.md
+++ b/README.md
@@ -275,3 +275,22 @@ struct ContentView: View {
 ```
 
 #### Supplying context on push
+
+Now that we set up an evaluation function, we can supply relevant context information when pushing programmatically.
+
+```swift
+stack.push(view: AnyView(Text("Pushed with evaluation")), context: ["expected" : "value"])
+```
+
+As you can see, context is a simple dictionary with string keys and arbitrary values. These values will be passed to our evaluation
+function and result in a push if it returns true.
+
+You don't have to call push to find out if a view _would_ be pushed though, for this purpose you can use `stack.evaluate`. Similar to `stack.push`, it accepts
+an optional context dictionary, and will run the evaluation logic. Internally, we use `stack.evaluate` when pushing, so the results will match.
+
+```swift
+stack.evaluate(["expected" : "value"])
+```
+
+If you don't pass a context dictionary to `stack.push` or `stack.evaluate`, we'll pass an empty dictionary instead. Thus the pusher evaluation function always receives
+a dictionary and always returns a boolean value.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ As you can see, you can go on and on (please split out your sub-views though).
 ### Push evaluation
 
 In specific cases, you might like to prevent pushes to the active pusher. If the view that you'd push is equal to the current view, for example, it wouldn't make
-much sense to push it to the stack again. Especially for programmatic navigation, it can be helpful to add a condition when a push should happen, and to be able
+much sense to push it to the stack again. Especially for programmatic navigation, it can be helpful to add a condition when a push should happen and to be able
 to check if a push would succeed. This is why Stapel offers Push evaluation for each registered pusher.
 
 Setting up push evaluation requires two steps: Adding an evaluation function to the pusher that you'd like to control, and supplying context when pushing.
@@ -190,7 +190,7 @@ Setting up push evaluation requires two steps: Adding an evaluation function to 
 During each push, we check whether an evaluation function was set for the pusher that would receive the view to be pushed.
 If no function exists, the push will _always_ be allowed.
 If an evaluation function is set, we will invoke it and pass the supplied context.
-If the evaluation function returns `true`, we'll push the view onto the stack, otherwise it'll be a no-op.
+If the evaluation function returns `true`, we'll push the view onto the stack, otherwise, it'll be a no-op.
 
 Let's see how we'd register an evaluation function on our root level. If this evaluates to false, we won't onto that.
 
@@ -226,7 +226,7 @@ struct ContentView: View {
 ```
 
 This will render two buttons on the root level, one that will supply the expected context and result in a push, and
-another one that will not push, as it doesn't supply a context (or an invaild context).
+another one that will not push, as it doesn't supply a context (or an invalid context).
 
 While this only affects the initial layer, we might also want to control subsequent layers. This can be done by supplying an evaluation
 function to `WithPusher`.

--- a/Sources/Stapel/Pusher.swift
+++ b/Sources/Stapel/Pusher.swift
@@ -89,7 +89,7 @@ public struct WithPusher<Content: View>: View {
     // Initialize stack layer with evaluation function
     /// - Parameter shouldPush: When this pusher is active, this function will decide whether a view should be pushed onto the stack
     /// - Parameter content: Views to render as children
-    public init(shouldPush: @escaping PusherEvalFunc, @ViewBuilder content: @escaping () -> Content) {
+    public init(_ shouldPush: @escaping PusherEvalFunc, @ViewBuilder content: @escaping () -> Content) {
         self.content = content()
         self.shouldPush = shouldPush
     }

--- a/Sources/Stapel/Pusher.swift
+++ b/Sources/Stapel/Pusher.swift
@@ -78,8 +78,18 @@ struct Pusher: View {
 public struct WithPusher<Content: View>: View {
     let shouldPush: PusherEvalFunc?
     let content: Content
-        
-    public init(shouldPush: PusherEvalFunc?, @ViewBuilder content: @escaping () -> Content) {
+
+    // Initialize stack layer
+    /// - Parameter content: Views to render as children
+    public init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content()
+        self.shouldPush = nil
+    }
+
+    // Initialize stack layer with evaluation function
+    /// - Parameter shouldPush: When this pusher is active, this function will decide whether a view should be pushed onto the stack
+    /// - Parameter content: Views to render as children
+    public init(shouldPush: @escaping PusherEvalFunc, @ViewBuilder content: @escaping () -> Content) {
         self.content = content()
         self.shouldPush = shouldPush
     }

--- a/Sources/Stapel/Pusher.swift
+++ b/Sources/Stapel/Pusher.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-typealias PusherEvalFunc = (([String: Any]) -> Bool)
+public typealias PusherEvalFunc = (([String: Any]) -> Bool)
 
 struct PusherState<T> {
     var view: StackViewType<T>
@@ -76,11 +76,12 @@ struct Pusher: View {
 ///       Text("Root View")
 ///     }
 public struct WithPusher<Content: View>: View {
-    let shouldPush: PusherEvalFunc? = nil
+    let shouldPush: PusherEvalFunc?
     let content: Content
-    
-    public init(@ViewBuilder content: @escaping () -> Content) {
+        
+    public init(shouldPush: PusherEvalFunc?, @ViewBuilder content: @escaping () -> Content) {
         self.content = content()
+        self.shouldPush = shouldPush
     }
     
     public var body: some View {

--- a/Sources/Stapel/Pusher.swift
+++ b/Sources/Stapel/Pusher.swift
@@ -1,5 +1,14 @@
 import SwiftUI
 
+struct PusherState<T> {
+    var view: StackViewType<T>
+    var evaluator: (([String: Any]) -> Bool)?
+    
+    init(_ view: StackViewType<T>) {
+        self.view = view
+    }
+}
+
 struct Pusher: View {
     // Assign time-based identifier to get incrementing
     // values for subsequent Pusher views instack. This is extremly
@@ -10,13 +19,13 @@ struct Pusher: View {
     @EnvironmentObject var stack: Stack
     
     @State var isActive = true
-        
+    
     func retrieveViewToRender() -> (AnyView?) {
-        guard let hasEntry = stack.views[id] else {
+        guard let hasEntry = stack.pushers[id] else {
             return nil
         }
         
-        guard case let .set(withView) = hasEntry else {
+        guard case let .set(withView) = hasEntry.view else {
             return nil
         }
         

--- a/Sources/Stapel/Pusher.swift
+++ b/Sources/Stapel/Pusher.swift
@@ -49,7 +49,7 @@ struct Pusher: View {
             // On appear, register in stack. If the current pusher
             // is already registered, this will be a noop
             .onAppear {
-                stack.register(pusher: id, evaluate: self.evaluate)
+                stack.register(id, self.evaluate)
             }
             // When the view is popped (value changes from true to false),
             // we'll pop the stack as well and reset the active flag

--- a/Sources/Stapel/Stack.swift
+++ b/Sources/Stapel/Stack.swift
@@ -34,7 +34,7 @@ public class AnyStack<T>: ObservableObject {
     ///       Text("Root View")
     ///     }
     public func push(view: T, context: [String: Any] = [:]) -> Void {
-        // Find top-most pusher to assign view to
+        // Find active pusher to assign view to
         guard let pusherId = activePusher() else {
             return
         }
@@ -101,7 +101,7 @@ public class AnyStack<T>: ObservableObject {
         })
     }
     
-    func register(pusher: Int, evaluate: PusherEvalFunc? = nil) -> Void {
+    func register(_ pusher: Int, _ evaluate: PusherEvalFunc? = nil) -> Void {
         guard !self.pushers.keys.contains(pusher) else {
             return
         }

--- a/Sources/Stapel/Stapel.swift
+++ b/Sources/Stapel/Stapel.swift
@@ -31,7 +31,7 @@ public struct WithStapel<Content: View>: View {
     ///   decide whether to push a view or not based on supplied context
     /// - Parameter content: Views to render as children
     ///
-    public init(shouldPush: @escaping PusherEvalFunc, @ViewBuilder content: @escaping () -> Content) {
+    public init(_ shouldPush: @escaping PusherEvalFunc, @ViewBuilder content: @escaping () -> Content) {
         self.content = content()
         self.shouldPush = shouldPush
     }
@@ -39,7 +39,7 @@ public struct WithStapel<Content: View>: View {
     public var body: some View {
         NavigationView {
             if let hasEvalFunc = shouldPush {
-                WithPusher(shouldPush: hasEvalFunc) {
+                WithPusher(hasEvalFunc) {
                     content
                 }
             } else {

--- a/Sources/Stapel/Stapel.swift
+++ b/Sources/Stapel/Stapel.swift
@@ -18,20 +18,11 @@ public struct WithStapel<Content: View>: View {
     
     /// Create WithStapel view
     ///
-    /// - Parameter content: Views to render as children
-    ///
-    public init(@ViewBuilder content: @escaping () -> Content) {
-        self.content = content()
-        self.shouldPush = nil
-    }
-    
-    /// Create WithStapel view with evaluation function
-    ///
-    /// - Parameter shouldPush: An evaluation function for the root-level pusher to
+    /// - Parameter shouldPush: An optional evaluation function for the root-level pusher to
     ///   decide whether to push a view or not based on supplied context
     /// - Parameter content: Views to render as children
     ///
-    public init(shouldPush: @escaping PusherEvalFunc, @ViewBuilder content: @escaping () -> Content) {
+    public init(_ shouldPush: PusherEvalFunc? = nil, @ViewBuilder content: @escaping () -> Content) {
         self.content = content()
         self.shouldPush = shouldPush
     }

--- a/Sources/Stapel/Stapel.swift
+++ b/Sources/Stapel/Stapel.swift
@@ -13,15 +13,32 @@ import SwiftUI
 @available(iOS 14, *)
 @available(macOS, unavailable) // Unfortunately, StackNavigationStyle is not available on macOS
 public struct WithStapel<Content: View>: View {
+    let shouldPush: PusherEvalFunc?
     let content: Content
     
+    /// Create WithStapel view
+    ///
+    /// - Parameter content: Views to render as children
+    ///
     public init(@ViewBuilder content: @escaping () -> Content) {
         self.content = content()
+        self.shouldPush = nil
+    }
+    
+    /// Create WithStapel view with evaluation function
+    ///
+    /// - Parameter shouldPush: An evaluation function for the root-level pusher to
+    ///   decide whether to push a view or not based on supplied context
+    /// - Parameter content: Views to render as children
+    ///
+    public init(shouldPush: @escaping PusherEvalFunc, @ViewBuilder content: @escaping () -> Content) {
+        self.content = content()
+        self.shouldPush = shouldPush
     }
         
     public var body: some View {
         NavigationView {
-            WithPusher {
+            WithPusher(shouldPush: shouldPush) {
                 content
             }
         }

--- a/Sources/Stapel/Stapel.swift
+++ b/Sources/Stapel/Stapel.swift
@@ -35,11 +35,17 @@ public struct WithStapel<Content: View>: View {
         self.content = content()
         self.shouldPush = shouldPush
     }
-        
+    
     public var body: some View {
         NavigationView {
-            WithPusher(shouldPush: shouldPush) {
-                content
+            if let hasEvalFunc = shouldPush {
+                WithPusher(shouldPush: hasEvalFunc) {
+                    content
+                }
+            } else {
+                WithPusher {
+                    content
+                }
             }
         }
         // This is crucial for natural stack behaviour

--- a/Sources/Stapel/Stapel.swift
+++ b/Sources/Stapel/Stapel.swift
@@ -18,11 +18,20 @@ public struct WithStapel<Content: View>: View {
     
     /// Create WithStapel view
     ///
-    /// - Parameter shouldPush: An optional evaluation function for the root-level pusher to
+    /// - Parameter content: Views to render as children
+    ///
+    public init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content()
+        self.shouldPush = nil
+    }
+    
+    /// Create WithStapel view with evaluation function
+    ///
+    /// - Parameter shouldPush: An evaluation function for the root-level pusher to
     ///   decide whether to push a view or not based on supplied context
     /// - Parameter content: Views to render as children
     ///
-    public init(_ shouldPush: PusherEvalFunc? = nil, @ViewBuilder content: @escaping () -> Content) {
+    public init(shouldPush: @escaping PusherEvalFunc, @ViewBuilder content: @escaping () -> Content) {
         self.content = content()
         self.shouldPush = shouldPush
     }

--- a/StapelUITests/StapelUITests.xcodeproj/project.pbxproj
+++ b/StapelUITests/StapelUITests.xcodeproj/project.pbxproj
@@ -469,8 +469,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/BrunoScheufler/Stapel.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				kind = exactVersion;
+				version = "1.1.0-alpha.6";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/StapelUITests/StapelUITests.xcodeproj/project.pbxproj
+++ b/StapelUITests/StapelUITests.xcodeproj/project.pbxproj
@@ -470,7 +470,7 @@
 			repositoryURL = "https://github.com/BrunoScheufler/Stapel.git";
 			requirement = {
 				kind = exactVersion;
-				version = "1.1.0-alpha.6";
+				version = 1.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/StapelUITests/StapelUITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StapelUITests/StapelUITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/BrunoScheufler/Stapel.git",
         "state": {
           "branch": null,
-          "revision": "1432bf04a6692e707675447f174271f8a1bd8189",
-          "version": "1.1.0-alpha.6"
+          "revision": "154b4e0ff93b2a8999b2c66776c78ec5c827be9e",
+          "version": "1.1.0"
         }
       }
     ]

--- a/StapelUITests/StapelUITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StapelUITests/StapelUITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Stapel",
+        "repositoryURL": "https://github.com/BrunoScheufler/Stapel.git",
+        "state": {
+          "branch": null,
+          "revision": "1432bf04a6692e707675447f174271f8a1bd8189",
+          "version": "1.1.0-alpha.6"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/StapelUITests/Tests/Tests.swift
+++ b/StapelUITests/Tests/Tests.swift
@@ -126,4 +126,29 @@ class Tests: XCTestCase {
         toSecond.tap()
         backToFirst.tap()
     }
+    
+    func testWithEvaluateTruthy() {
+        let app = launchApp("evaluate")
+
+        XCTAssert(app.staticTexts["Root view"].exists)
+        
+        let shouldntPush = app.buttons["Push falsy"]
+        shouldntPush.tap()
+        
+        XCTAssert(app.staticTexts["Root view"].exists)
+        XCTAssert(!app.staticTexts["No-op"].exists)
+    }
+    
+    func testWithEvaluateFalsy() {
+        let app = launchApp("evaluate")
+
+        XCTAssert(app.staticTexts["Root view"].exists)
+        
+        let shouldntPush = app.buttons["Push truthy"]
+        shouldntPush.tap()
+        
+        XCTAssert(!app.staticTexts["Root view"].exists)
+        XCTAssert(app.staticTexts["Pushed with evaluation"].exists)
+
+    }
 }

--- a/StapelUITests/Tests/Tests.swift
+++ b/StapelUITests/Tests/Tests.swift
@@ -127,8 +127,8 @@ class Tests: XCTestCase {
         backToFirst.tap()
     }
     
-    func testWithEvaluateTruthy() {
-        let app = launchApp("evaluate")
+    func testWithEvaluateRootTruthy() {
+        let app = launchApp("evaluate_root")
 
         XCTAssert(app.staticTexts["Root view"].exists)
         
@@ -139,8 +139,8 @@ class Tests: XCTestCase {
         XCTAssert(!app.staticTexts["No-op"].exists)
     }
     
-    func testWithEvaluateFalsy() {
-        let app = launchApp("evaluate")
+    func testWithEvaluateRootFalsy() {
+        let app = launchApp("evaluate_root")
 
         XCTAssert(app.staticTexts["Root view"].exists)
         
@@ -148,6 +148,41 @@ class Tests: XCTestCase {
         shouldntPush.tap()
         
         XCTAssert(!app.staticTexts["Root view"].exists)
+        XCTAssert(app.staticTexts["Pushed with evaluation"].exists)
+
+    }
+    
+    func testWithEvaluateNestedTruthy() {
+        let app = launchApp("evaluate_nested")
+
+        XCTAssert(app.staticTexts["Root view"].exists)
+        
+        app.buttons["Push"].tap()
+
+        XCTAssert(!app.staticTexts["Root view"].exists)
+        XCTAssert(app.staticTexts["Second view"].exists)
+
+        let shouldntPush = app.buttons["Push falsy"]
+        shouldntPush.tap()
+        
+        XCTAssert(app.staticTexts["Second view"].exists)
+        XCTAssert(!app.staticTexts["No-op"].exists)
+    }
+    
+    func testWithEvaluateNestedFalsy() {
+        let app = launchApp("evaluate_nested")
+
+        XCTAssert(app.staticTexts["Root view"].exists)
+        
+        app.buttons["Push"].tap()
+
+        XCTAssert(!app.staticTexts["Root view"].exists)
+        XCTAssert(app.staticTexts["Second view"].exists)
+        
+        let shouldntPush = app.buttons["Push truthy"]
+        shouldntPush.tap()
+        
+        XCTAssert(!app.staticTexts["Second view"].exists)
         XCTAssert(app.staticTexts["Pushed with evaluation"].exists)
 
     }

--- a/Tests/StapelTests/StapelTests.swift
+++ b/Tests/StapelTests/StapelTests.swift
@@ -7,18 +7,18 @@ import SwiftUI
 final class StapelTests: XCTestCase {
     func testInitialStackEmpty() {
         let s = Stack()
-        XCTAssertEqual(s.views.count, 0)
+        XCTAssertEqual(s.pushers.count, 0)
     }
     
     func testRegister() throws {
         let s = Stack()
         s.register(pusher: 0)
         
-        XCTAssertEqual(s.views.count, 1)
+        XCTAssertEqual(s.pushers.count, 1)
         
-        let pusher = try XCTUnwrap(s.views[0])
+        let pusher = try XCTUnwrap(s.pushers[0])
         
-        guard case .empty = pusher else {
+        guard case .empty = pusher.view else {
             XCTFail("Expected pusher to be empty")
             return
         }
@@ -32,9 +32,9 @@ final class StapelTests: XCTestCase {
         
         s.push(view: testView)
         
-        let pushedView = try XCTUnwrap(s.views[0])
+        let rootPusher = try XCTUnwrap(s.pushers[0])
         
-        guard case let .set(pushedViewContents) = pushedView else {
+        guard case let .set(pushedViewContents) = rootPusher.view else {
             XCTFail("Expected set view")
             return
         }
@@ -44,13 +44,13 @@ final class StapelTests: XCTestCase {
     
     func testStackPop() throws {
         let s = AnyStack<String>()
-        s.views[0] = .set("test")
+        s.pushers[0] = PusherState(.set("test"))
         
         s.pusherPop(0)
         
-        let found = try XCTUnwrap(s.views[0])
+        let found = try XCTUnwrap(s.pushers[0])
         
-        guard case .empty = found else {
+        guard case .empty = found.view else {
             XCTFail("Expected pusher to be empty")
             return
         }
@@ -58,15 +58,15 @@ final class StapelTests: XCTestCase {
     
     func testPopIdempotent() throws {
         let s = AnyStack<String>()
-        s.views[0] = .set("test")
+        s.pushers[0] = PusherState(.set("test"))
         
         s.pusherPop(0)
         s.pusherPop(0)
         s.pusherPop(0)
         
-        let found = try XCTUnwrap(s.views[0])
+        let found = try XCTUnwrap(s.pushers[0])
         
-        guard case .empty = found else {
+        guard case .empty = found.view else {
             XCTFail("Expected pusher to be empty")
             return
         }
@@ -76,9 +76,9 @@ final class StapelTests: XCTestCase {
         let s = AnyStack<String>()
         
         func pusherSet(_ pusher: Int, _ to: String) throws {
-            let detailPusher = try XCTUnwrap(s.views[pusher])
+            let detailPusher = try XCTUnwrap(s.pushers[pusher])
             
-            guard case let .set(detailPusherSet) = detailPusher else {
+            guard case let .set(detailPusherSet) = detailPusher.view else {
                 XCTFail("Expected pusher \(pusher) to be set")
                 return
             }
@@ -87,36 +87,36 @@ final class StapelTests: XCTestCase {
         }
         
         func pusherEmpty(_ pusher: Int) throws {
-            let detailPusher = try XCTUnwrap(s.views[pusher])
+            let detailPusher = try XCTUnwrap(s.pushers[pusher])
             
-            guard case .empty = detailPusher else {
+            guard case .empty = detailPusher.view else {
                 XCTFail("Expected pusher \(pusher) to be empty")
                 return
             }
         }
         
         func pusherUnregistered(_ pusher: Int) {
-            XCTAssertFalse(s.views.keys.contains(pusher))
+            XCTAssertFalse(s.pushers.keys.contains(pusher))
         }
         
-        XCTAssertEqual(s.views.count, 0)
+        XCTAssertEqual(s.pushers.count, 0)
         
         s.register(pusher: 0)
         
         s.push(view: "list")
         s.register(pusher: 1)
         
-        XCTAssertEqual(s.views.count, 2)
+        XCTAssertEqual(s.pushers.count, 2)
         
         s.push(view: "detail")
         s.register(pusher: 2)
         
-        XCTAssertEqual(s.views.count, 3)
+        XCTAssertEqual(s.pushers.count, 3)
         
         s.push(view: "adhoc")
         // this view does not register a pusher
         
-        XCTAssertEqual(s.views.count, 3)
+        XCTAssertEqual(s.pushers.count, 3)
         
         try pusherSet(0, "list")
         try pusherSet(1, "detail")
@@ -128,7 +128,7 @@ final class StapelTests: XCTestCase {
         // we don't expect detail pusher to be removed yet as
         // it is empty after the pop
         
-        XCTAssertEqual(s.views.count, 3)
+        XCTAssertEqual(s.pushers.count, 3)
         
         try pusherSet(0, "list")
         try pusherSet(1, "detail")
@@ -140,7 +140,7 @@ final class StapelTests: XCTestCase {
         // now we're viewing the list view (with an empty pusher 1)
         // detail pusher should have been removed (count decreased)
         
-        XCTAssertEqual(s.views.count, 2)
+        XCTAssertEqual(s.pushers.count, 2)
         
         try pusherSet(0, "list")
         try pusherEmpty(1)

--- a/Tests/StapelTests/StapelTests.swift
+++ b/Tests/StapelTests/StapelTests.swift
@@ -5,14 +5,16 @@ import SwiftUI
 
 
 final class StapelTests: XCTestCase {
+    // Creating stack should yield empty stack
     func testInitialStackEmpty() {
         let s = Stack()
         XCTAssertEqual(s.pushers.count, 0)
     }
     
+    // Registering pusher should increase stack count and create empty pusher state
     func testRegister() throws {
         let s = Stack()
-        s.register(pusher: 0)
+        s.register(0)
         
         XCTAssertEqual(s.pushers.count, 1)
         
@@ -24,9 +26,10 @@ final class StapelTests: XCTestCase {
         }
     }
     
+    // Pushing view on stack should assign view to active pusher
     func testStackPush() throws {
         let s = AnyStack<String>()
-        s.register(pusher: 0)
+        s.register(0)
         
         let testView = "test"
         
@@ -42,6 +45,7 @@ final class StapelTests: XCTestCase {
         XCTAssertEqual(pushedViewContents, testView)
     }
     
+    // Popping view should empty state of active pusher
     func testStackPop() throws {
         let s = AnyStack<String>()
         s.pushers[0] = PusherState(.set("test"))
@@ -56,6 +60,9 @@ final class StapelTests: XCTestCase {
         }
     }
     
+    // Popping the same pusher multiple times should not change the outcome
+    // This is just a safeguard against SwiftUI acting weird, although this shouldn't happen
+    // in StackNavigation mode
     func testPopIdempotent() throws {
         let s = AnyStack<String>()
         s.pushers[0] = PusherState(.set("test"))
@@ -72,6 +79,7 @@ final class StapelTests: XCTestCase {
         }
     }
     
+    // Test expected use case of nested navigation with multiple push and pop operations
     func testMulti() throws {
         let s = AnyStack<String>()
         
@@ -101,15 +109,15 @@ final class StapelTests: XCTestCase {
         
         XCTAssertEqual(s.pushers.count, 0)
         
-        s.register(pusher: 0)
+        s.register(0)
         
         s.push(view: "list")
-        s.register(pusher: 1)
+        s.register(1)
         
         XCTAssertEqual(s.pushers.count, 2)
         
         s.push(view: "detail")
-        s.register(pusher: 2)
+        s.register(2)
         
         XCTAssertEqual(s.pushers.count, 3)
         
@@ -153,12 +161,78 @@ final class StapelTests: XCTestCase {
         try pusherSet(1, "another")
     }
     
+    // Test evaluation with default (no eval func supplied)
+    func testEvaluateEmpty() {
+        let s = AnyStack<String>()
+        s.register(0)
+        XCTAssertTrue(s.evaluate())
+    }
+    
+    // Test evaluation with always-true eval func
+    func testEvaluateAlways() {
+        let s = AnyStack<String>()
+        s.register(0, { (context) -> Bool in
+            return true
+        })
+        
+        XCTAssertTrue(s.evaluate())
+        XCTAssertTrue(s.evaluate(["still": true]))
+    }
+    
+    // Test evaluation with context-dependent eval func, success case
+    func testEvaluateOnContextTruthy() {
+        let s = AnyStack<String>()
+        s.register(0, { (context) -> Bool in
+            guard let hasValue = context["expected"] else {
+                return false
+            }
+            guard let asBool = hasValue as? Bool else {
+                return false
+            }
+            return asBool
+        })
+        
+        XCTAssertTrue(s.evaluate(["expected": true]))
+    }
+    
+    // Test evaluation with context-dependent eval func, fail case
+    func testEvaluateOnContextFalsy() {
+        let s = AnyStack<String>()
+        s.register(0, { (context) -> Bool in
+            guard let hasValue = context["expected"] else {
+                return false
+            }
+            guard let asBool = hasValue as? Bool else {
+                return false
+            }
+            return asBool
+        })
+        
+        XCTAssertFalse(s.evaluate(["expected": "invalid"]))
+    }
+    
+    // Test evaluation with always-false eval func
+    func testEvaluateNever() {
+        let s = AnyStack<String>()
+        s.register(0, { (context) -> Bool in
+            return false
+        })
+        
+        XCTAssertFalse(s.evaluate())
+        XCTAssertFalse(s.evaluate(["still": false]))
+    }
+    
     
     static var allTests = [
         ("testInitialStackEmpty", testInitialStackEmpty),
         ("testStackPush", testStackPush),
         ("testStackPop", testStackPop),
         ("testPopIdempotent", testPopIdempotent),
-        ("testMulti", testMulti)
+        ("testMulti", testMulti),
+        ("testEvaluateEmpty", testEvaluateEmpty),
+        ("testEvaluateOnContextTruthy", testEvaluateOnContextTruthy),
+        ("testEvaluateOnContextFalsy", testEvaluateOnContextFalsy),
+        ("testEvaluateAlways", testEvaluateAlways),
+        ("testEvaluateNever", testEvaluateNever),
     ]
 }


### PR DESCRIPTION
This PR introduces a new concept called `push evaluation`. It allows to register evaluation functions that decide whether a view will be pushed onto a stack or not, and a tied to the current context, as each pusher registers an individual function.