### PR TITLE
Use native NavigationLink as StackNavigationLink button

### DIFF
--- a/Sources/Stapel/Pusher.swift
+++ b/Sources/Stapel/Pusher.swift
@@ -59,10 +59,8 @@ struct Pusher: View {
                 }
                 
                 // Pop view from stack, set pusher to empty
-                withAnimation {
-                    stack.pusherPop(id)
-                    isActive = true
-                }
+                stack.pusherPop(id)
+                isActive = true
             })
     }
 }
@@ -78,14 +76,14 @@ struct Pusher: View {
 public struct WithPusher<Content: View>: View {
     let shouldPush: PusherEvalFunc?
     let content: Content
-
+    
     // Initialize stack layer
     /// - Parameter content: Views to render as children
     public init(@ViewBuilder content: @escaping () -> Content) {
         self.content = content()
         self.shouldPush = nil
     }
-
+    
     // Initialize stack layer with evaluation function
     /// - Parameter shouldPush: When this pusher is active, this function will decide whether a view should be pushed onto the stack
     /// - Parameter content: Views to render as children

--- a/Sources/Stapel/Stack.swift
+++ b/Sources/Stapel/Stack.swift
@@ -44,9 +44,7 @@ public class AnyStack<T>: ObservableObject {
             return
         }
         
-        withAnimation {
-            updatePusherView(pusherId, .set(view))
-        }
+        updatePusherView(pusherId, .set(view))    
     }
     
     /// Evaluate whether a given context would be pushed onto the stack

--- a/Sources/Stapel/StackNavigationLink.swift
+++ b/Sources/Stapel/StackNavigationLink.swift
@@ -20,10 +20,14 @@ public struct StackNavigationLink<Label: View, Content: View>: View {
     @EnvironmentObject var stack: Stack
     
     public var body: some View {
-        Button(action: {
-            stack.push(view: AnyView(content))
-        }, label: {
-            label
-        })
+        NavigationLink(
+            destination: EmptyView(),
+            isActive: .constant(false),
+            label: {
+                label
+            })
+            .onTapGesture {
+                stack.push(view: AnyView(content))
+            }
     }
 }

--- a/StapelUITests/StapelUITests.xcodeproj/project.pbxproj
+++ b/StapelUITests/StapelUITests.xcodeproj/project.pbxproj
@@ -470,7 +470,7 @@
 			repositoryURL = "https://github.com/BrunoScheufler/Stapel.git";
 			requirement = {
 				kind = exactVersion;
-				version = 1.1.0;
+				version = 1.1.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/StapelUITests/StapelUITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StapelUITests/StapelUITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/BrunoScheufler/Stapel.git",
         "state": {
           "branch": null,
-          "revision": "154b4e0ff93b2a8999b2c66776c78ec5c827be9e",
-          "version": "1.1.0"
+          "revision": "0b422f57591477c845a7176dc8d9314c5eb58a81",
+          "version": "1.1.1"
         }
       }
     ]


### PR DESCRIPTION
Until now, we rendered a regular button, which wouldn't render the arrows in list items and other differences that appear when a real NavigationLink is used. This is now changed. We also remove implicit animations that might not be wanted.